### PR TITLE
Implement single-select RACI role picker with inline custom entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -574,18 +574,20 @@
             };
 
             const createRoleCell = (role, values = [], index) => {
-                const normalizedValues = Array.isArray(values) ? values : String(values).split(',').map(v => v.trim()).filter(Boolean);
-                const options = getAllPeople(normalizedValues);
+                const normalizedValues = Array.isArray(values)
+                    ? values
+                    : String(values).split(',').map(v => v.trim()).filter(Boolean);
+                const selectedValue = normalizedValues[0] || '';
+                const options = getAllPeople([selectedValue]);
                 return `
                     <td>
                         <div class="space-y-2">
-                            <select multiple class="editable-select" data-field="${role}">
-                                ${options.map(person => `<option value="${escapeHTML(person)}" ${normalizedValues.includes(person) ? 'selected' : ''}>${escapeHTML(person)}</option>`).join('')}
+                            <select class="editable-select" data-field="${role}" data-index="${index}">
+                                <option value="" ${selectedValue ? '' : 'selected'} disabled>Select a person</option>
+                                ${options.map(person => `<option value="${escapeHTML(person)}" ${selectedValue === person ? 'selected' : ''}>${escapeHTML(person)}</option>`).join('')}
+                                <option value="__custom__">[Custom text…]</option>
                             </select>
-                            <div class="flex items-center justify-between">
-                                <span class="text-xs text-slate-400">Ctrl/Cmd+Click for multi-select</span>
-                                <button type="button" class="table-inline-action" data-action="add-person" data-role="${role}" data-index="${index}">+ Add custom</button>
-                            </div>
+                            <input type="text" class="editable-input hidden" data-custom-input="${role}" data-index="${index}" placeholder="Enter custom label">
                         </div>
                     </td>
                 `;
@@ -611,6 +613,26 @@
             };
 
             renderRaciTable();
+
+            const commitCustomInput = (input) => {
+                if (!input || input.dataset.processed === 'true') return;
+                input.dataset.processed = 'true';
+                const field = input.dataset.field;
+                const index = parseInt(input.dataset.index, 10);
+                if (!field || Number.isNaN(index)) {
+                    renderRaciTable();
+                    return;
+                }
+                const value = input.value.trim();
+                const previousValue = input.dataset.previousValue || '';
+                if (value) {
+                    customPeople.add(value);
+                    projectData.raciData[index][field] = [value];
+                } else {
+                    projectData.raciData[index][field] = previousValue ? [previousValue] : [];
+                }
+                renderRaciTable();
+            };
 
             raciTable.addEventListener('input', (event) => {
                 const target = event.target;
@@ -649,35 +671,59 @@
                 if (Number.isNaN(index)) return;
                 const field = target.dataset.field;
 
-                if (target.multiple && field) {
-                    projectData.raciData[index][field] = Array.from(target.selectedOptions).map(option => option.value);
-                }
-
                 if (field === 'dueDateType') {
                     projectData.raciData[index].dueDate.type = target.value;
                     if (target.value === 'text' && !projectData.raciData[index].dueDate.value) {
                         projectData.raciData[index].dueDate.value = '';
                     }
                     renderRaciTable();
+                    return;
+                }
+
+                if (field && target.matches('select')) {
+                    if (!Array.isArray(projectData.raciData[index][field])) {
+                        projectData.raciData[index][field] = [];
+                    }
+                    const input = target.parentElement.querySelector(`input[data-custom-input="${field}"]`);
+                    if (target.value === '__custom__') {
+                        if (input) {
+                            input.classList.remove('hidden');
+                            input.value = '';
+                            delete input.dataset.processed;
+                            input.dataset.field = field;
+                            input.dataset.index = String(index);
+                            input.dataset.previousValue = projectData.raciData[index][field][0] || '';
+                            target.classList.add('hidden');
+                            setTimeout(() => input.focus(), 0);
+                        }
+                        return;
+                    }
+
+                    if (input) {
+                        input.classList.add('hidden');
+                        input.value = '';
+                        delete input.dataset.field;
+                        delete input.dataset.index;
+                        delete input.dataset.previousValue;
+                        delete input.dataset.processed;
+                    }
+                    target.classList.remove('hidden');
+                    projectData.raciData[index][field] = target.value ? [target.value] : [];
                 }
             });
 
-            raciTable.addEventListener('click', (event) => {
-                const button = event.target.closest('[data-action="add-person"]');
-                if (!button) return;
-                const index = parseInt(button.dataset.index, 10);
-                const role = button.dataset.role;
-                if (Number.isNaN(index) || !role) return;
-                const response = prompt('Enter a custom name, role, or group:');
-                if (response) {
-                    const trimmed = response.trim();
-                    if (trimmed) {
-                        customPeople.add(trimmed);
-                        if (!projectData.raciData[index][role].includes(trimmed)) {
-                            projectData.raciData[index][role].push(trimmed);
-                        }
-                        renderRaciTable();
-                    }
+            raciTable.addEventListener('keydown', (event) => {
+                const input = event.target;
+                if (input.matches('input[data-custom-input]') && event.key === 'Enter') {
+                    event.preventDefault();
+                    commitCustomInput(input);
+                }
+            });
+
+            raciTable.addEventListener('focusout', (event) => {
+                const input = event.target;
+                if (input.matches('input[data-custom-input]')) {
+                    commitCustomInput(input);
                 }
             });
 


### PR DESCRIPTION
## Summary
- render RACI role cells as single-select dropdowns with a custom entry option instead of multi-select pickers
- add inline custom person input handling that persists selections while keeping stored role data as arrays

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb7e26dd4c83318a4bb2187a566aea