### PR TITLE
Renumber project plan sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
 
         <!-- Timeline Section -->
         <section id="timeline" class="mb-12">
-            <h2 class="text-2xl font-bold text-slate-800 mb-4">III. Master Project Timeline</h2>
+            <h2 class="text-2xl font-bold text-slate-800 mb-4">II. Master Project Timeline</h2>
             <p class="text-slate-600 mb-6 max-w-4xl">This is the detailed, execution-focused roadmap for the project. The interactive timeline below provides a visual overview of the major tasks and phases. Click on any task bar to view more details.</p>
             <div class="bg-white rounded-lg shadow-lg">
                 <div id="gantt-wrapper" class="overflow-auto" style="max-height: 60vh;">
@@ -242,14 +242,14 @@
 
         <!-- Phases & Deliverables -->
         <section id="phases" class="mb-12">
-            <h2 class="text-2xl font-bold text-slate-800 mb-4">Phased Work Plan Details</h2>
+            <h3 class="text-xl font-semibold text-slate-800 mb-3">II.A Phased Work Plan Details</h3>
              <p class="text-slate-600 mb-6 max-w-4xl">The project is organized into four distinct phases. Click on a phase below to expand its details and see the associated objective, timeframe, and key activities.</p>
             <div id="phases-accordion" class="space-y-4"></div>
         </section>
 
         <!-- Team & Workload -->
         <section id="team" class="mb-12">
-            <h2 class="text-2xl font-bold text-slate-800 mb-4">II. Team Structure & Operating Model</h2>
+            <h2 class="text-2xl font-bold text-slate-800 mb-4">III. Team Structure & Operating Model</h2>
             <p class="text-slate-600 mb-6 max-w-4xl">This section defines our team's roles, responsibilities, and the operational cadence that will drive progress and ensure seamless collaboration.</p>
             <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
                 <div class="lg:col-span-1 bg-white p-6 rounded-lg shadow-lg">


### PR DESCRIPTION
## Summary
- renumbered the timeline and team headings so the page's roman-numeral sections flow I through IV in the order presented
- treated the phased work plan as a subsection (II.A) to keep numbering contiguous while preserving deep-dive content

## Testing
- Verified headings render at desktop and mobile viewports via Playwright

------
https://chatgpt.com/codex/tasks/task_e_68cb844b33688331bca20399f2592838