### PR TITLE
Add overview navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,6 +167,7 @@
                 </div>
                 <div class="hidden md:block">
                     <div class="ml-10 flex items-baseline space-x-4">
+                        <a href="#overview" class="text-slate-600 hover:bg-slate-100 hover:text-slate-900 px-3 py-2 rounded-md text-sm font-medium">Overview</a>
                         <a href="#timeline" class="text-slate-600 hover:bg-slate-100 hover:text-slate-900 px-3 py-2 rounded-md text-sm font-medium">Timeline</a>
                         <a href="#phases" class="text-slate-600 hover:bg-slate-100 hover:text-slate-900 px-3 py-2 rounded-md text-sm font-medium">Phases</a>
                         <a href="#team" class="text-slate-600 hover:bg-slate-100 hover:text-slate-900 px-3 py-2 rounded-md text-sm font-medium">Team</a>
@@ -175,6 +176,7 @@
                 </div>
                 <div class="md:hidden">
                     <select id="mobile-nav" class="bg-slate-100 border border-slate-300 rounded-md px-3 py-2 text-sm font-medium">
+                        <option value="#overview">Overview</option>
                         <option value="#timeline">Timeline</option>
                         <option value="#phases">Phases</option>
                         <option value="#team">Team</option>


### PR DESCRIPTION
## Summary
- add an Overview link to the desktop navigation so it mirrors the page sections
- include a matching Overview option in the mobile navigation select element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb84504fa083319b76367c9150bf6c