### PR TITLE
Align site styling with UCLA brand colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,23 +12,34 @@
     <!-- Visualization & Content Choices: Report Info: Team workload distribution (Core Execution 75%, Strategic Advisory 15%, Content Expertise 10%). Goal: Inform users of the planned effort distribution. Viz/Presentation: Doughnut Chart. Interaction: Hovering over segments shows the team member's name and workload percentage. Justification: A doughnut chart is an immediate and universally understood way to show parts of a whole, making the workload split instantly clear. Library: Chart.js (Canvas). Report Info: Project tasks with start/end dates and dependencies. Goal: Organize and visualize the project schedule over time. Viz/Presentation: HTML/CSS Gantt-style timeline. Interaction: Clicking on a task bar opens a modal with details. Justification: A Gantt view is the standard for project management, clearly showing task duration, overlap for parallel work, and sequencing for dependent tasks. Method: Custom JS with Tailwind CSS. Report Info: Detailed descriptions of SOW deliverables by phase. Goal: Inform and Organize. Viz/Presentation: Accordion list. Interaction: Clicking a phase title expands it to show detailed tasks. Justification: An accordion prevents information overload by hiding details until requested, keeping the main view clean. Method: Custom JS. -->
     <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
     <style>
+        :root {
+            --ucla-blue: #2774AE;
+            --ucla-gold: #FFD100;
+            --ucla-dark-blue: #1A5490;
+            --ucla-light-blue: #8BB8E8;
+            --ucla-dark-gold: #FFB300;
+            --ucla-dark-gray: #2D3748;
+            --ucla-medium-gray: #718096;
+            --ucla-light-gray: #F7FAFC;
+            --ucla-white: #FFFFFF;
+        }
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #F7FAFC; /* UCLA Light Gray */
+            background-color: var(--ucla-light-gray);
         }
         .gantt-grid {
             display: grid;
             grid-template-columns: 150px repeat(11, 1fr); /* Adjusted for new date range */
             gap: 1px;
-            background-color: #718096; /* UCLA Medium Gray */
+            background-color: var(--ucla-medium-gray);
         }
         .gantt-header {
-            background-color: #F7FAFC; /* UCLA Light Gray */
+            background-color: var(--ucla-light-gray);
             padding: 0.5rem;
             text-align: center;
             font-size: 0.75rem;
             font-weight: 600;
-            color: #2D3748; /* UCLA Dark Gray */
+            color: var(--ucla-dark-gray);
             position: -webkit-sticky; /* Safari support */
             position: sticky;
             top: 0;
@@ -59,20 +70,20 @@
             width: 0.25rem;
             height: 60%;
             border-radius: 9999px;
-            background-color: #8BB8E8; /* UCLA Lighter Blue */
+            background-color: var(--ucla-light-blue);
         }
         .timeline-unlocked .gantt-header-handle {
             display: flex;
         }
         .gantt-task-name {
-            background-color: #ffffff;
+            background-color: var(--ucla-white);
             padding: 0.5rem;
             font-size: 0.75rem;
             font-weight: 500;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
-            border-bottom: 1px solid #718096; /* UCLA Medium Gray */
+            border-bottom: 1px solid var(--ucla-medium-gray);
             position: -webkit-sticky; /* Safari support */
             position: sticky;
             left: 0;
@@ -82,15 +93,15 @@
             display: contents;
         }
         .gantt-cell {
-            background-color: #ffffff;
-            border-bottom: 1px solid #718096; /* UCLA Medium Gray */
+            background-color: var(--ucla-white);
+            border-bottom: 1px solid var(--ucla-medium-gray);
             position: relative;
         }
         .gantt-bar {
             position: absolute;
             height: 75%;
             top: 12.5%;
-            background-color: #2774AE; /* UCLA Blue */
+            background-color: var(--ucla-blue);
             border-radius: 0.25rem;
             cursor: pointer;
             transition: all 0.2s ease-in-out;
@@ -115,14 +126,14 @@
         .raci-table th, .raci-table td {
             padding: 0.75rem;
             text-align: left;
-            border-bottom: 1px solid #718096; /* UCLA Medium Gray */
+            border-bottom: 1px solid var(--ucla-medium-gray);
             position: relative;
             overflow: hidden;
             text-overflow: ellipsis;
             word-wrap: break-word;
         }
         .raci-table th {
-            background-color: #F7FAFC; /* UCLA Light Gray */
+            background-color: var(--ucla-light-gray);
             position: sticky;
             top: 0;
             z-index: 10;
@@ -141,11 +152,11 @@
         .raci-table-resizer:hover,
         .raci-table-resizer.active {
             opacity: 1;
-            background-color: #8BB8E8; /* UCLA Lighter Blue */
+            background-color: var(--ucla-light-blue);
         }
         .raci-table th:hover .raci-table-resizer {
             opacity: 1;
-            background-color: #8BB8E8; /* UCLA Lighter Blue */
+            background-color: var(--ucla-light-blue);
         }
         .text-wrap {
             white-space: pre-wrap;
@@ -165,30 +176,30 @@
             z-index: 1000;
         }
         .password-modal {
-            background-color: white;
+            background-color: var(--ucla-white);
             padding: 2rem;
             border-radius: 0.5rem;
-            box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 20px 25px -5px rgba(45, 55, 72, 0.1);
             max-width: 400px;
             width: 90%;
         }
         .password-input {
             width: 100%;
             padding: 0.75rem;
-            border: 1px solid #8BB8E8;
+            border: 1px solid var(--ucla-light-blue);
             border-radius: 0.375rem;
             font-size: 1rem;
-            color: #2D3748;
-            background-color: #F7FAFC;
+            color: var(--ucla-dark-gray);
+            background-color: var(--ucla-light-gray);
         }
         .password-input:focus {
             outline: none;
-            border-color: #2774AE;
+            border-color: var(--ucla-blue);
             box-shadow: 0 0 0 3px rgba(39, 116, 174, 0.25);
         }
         .password-button {
-            background-color: #2774AE;
-            color: white;
+            background-color: var(--ucla-blue);
+            color: var(--ucla-white);
             padding: 0.75rem 1.5rem;
             border: none;
             border-radius: 0.375rem;
@@ -197,7 +208,7 @@
             transition: background-color 0.2s ease;
         }
         .password-button:hover {
-            background-color: #1A5490;
+            background-color: var(--ucla-dark-blue);
         }
         .password-overlay.hidden {
             display: none !important;
@@ -207,19 +218,19 @@
             padding: 0.25rem 0.5rem;
             border-radius: 0.25rem;
             font-weight: 600;
-            color: white;
+            color: var(--ucla-white);
             font-size: 0.75rem;
         }
         .editable-input,
         .editable-select,
         .editable-textarea {
             width: 100%;
-            border: 1px solid #8BB8E8; /* UCLA Lighter Blue */
+            border: 1px solid var(--ucla-light-blue);
             border-radius: 0.375rem;
             padding: 0.5rem;
             font-size: 0.875rem;
-            color: #2D3748; /* UCLA Dark Gray */
-            background-color: #F7FAFC; /* UCLA Light Gray */
+            color: var(--ucla-dark-gray);
+            background-color: var(--ucla-light-gray);
             transition: border-color 0.2s ease, box-shadow 0.2s ease;
         }
         .editable-textarea {
@@ -231,9 +242,9 @@
         .editable-select:focus,
         .editable-textarea:focus {
             outline: none;
-            border-color: #2774AE; /* UCLA Blue */
+            border-color: var(--ucla-blue);
             box-shadow: 0 0 0 3px rgba(39, 116, 174, 0.25); /* UCLA Blue with opacity */
-            background-color: #ffffff;
+            background-color: var(--ucla-white);
         }
         .editable-select[multiple] {
             min-height: 120px;
@@ -245,34 +256,34 @@
             padding: 0.5rem 0.75rem;
             border-radius: 0.5rem;
             font-weight: 600;
-            background-color: #2774AE; /* UCLA Blue */
-            color: white;
+            background-color: var(--ucla-blue);
+            color: var(--ucla-white);
             transition: background-color 0.2s ease;
         }
         .table-control-button:hover {
-            background-color: #1A5490; /* UCLA Darker Blue */
+            background-color: var(--ucla-dark-blue);
         }
         .table-control-button:disabled {
             opacity: 0.6;
             cursor: not-allowed;
-            background-color: #8BB8E8; /* UCLA Lighter Blue */
+            background-color: var(--ucla-light-blue);
         }
         .table-control-button--secondary {
-            background-color: #718096; /* UCLA Medium Gray */
+            background-color: var(--ucla-medium-gray);
         }
         .table-control-button--secondary:hover {
-            background-color: #2D3748; /* UCLA Dark Gray */
+            background-color: var(--ucla-dark-gray);
         }
         .table-control-button--secondary.table-control-button--active {
-            background-color: #2D3748; /* UCLA Dark Gray */
+            background-color: var(--ucla-dark-gray);
         }
         .table-control-button--secondary.table-control-button--active:hover {
-            background-color: #2D3748; /* UCLA Dark Gray */
+            background-color: var(--ucla-dark-gray);
         }
         .table-inline-action {
             font-size: 0.75rem;
             font-weight: 600;
-            color: #2774AE; /* UCLA Blue */
+            color: var(--ucla-blue);
             cursor: pointer;
         }
         .table-inline-action:hover {
@@ -280,12 +291,12 @@
         }
         .timeline-textarea {
             width: 100%;
-            border: 1px solid #8BB8E8; /* UCLA Lighter Blue */
+            border: 1px solid var(--ucla-light-blue);
             border-radius: 0.375rem;
             padding: 0.5rem;
             font-size: 0.75rem;
-            color: #2D3748; /* UCLA Dark Gray */
-            background-color: #F7FAFC; /* UCLA Light Gray */
+            color: var(--ucla-dark-gray);
+            background-color: var(--ucla-light-gray);
             transition: border-color 0.2s ease, box-shadow 0.2s ease;
             resize: vertical;
             white-space: pre-wrap;
@@ -294,9 +305,9 @@
         }
         .timeline-textarea:focus {
             outline: none;
-            border-color: #2774AE; /* UCLA Blue */
+            border-color: var(--ucla-blue);
             box-shadow: 0 0 0 3px rgba(39, 116, 174, 0.25); /* UCLA Blue with opacity */
-            background-color: #ffffff;
+            background-color: var(--ucla-white);
         }
         .gantt-task-name--editable {
             white-space: pre-wrap;
@@ -306,7 +317,7 @@
         }
         .gantt-cell--editing {
             padding: 0.25rem;
-            background-color: #F7FAFC; /* UCLA Light Gray */
+            background-color: var(--ucla-light-gray);
         }
         .timeline-cell-editor-container {
             display: flex;
@@ -319,17 +330,79 @@
             flex-direction: column;
             font-size: 0.625rem;
             font-weight: 600;
-            color: #475569;
+            color: var(--ucla-medium-gray);
             gap: 0.25rem;
         }
         .timeline-boundary-input {
             width: 100%;
-            border: 1px solid #8BB8E8; /* UCLA Lighter Blue */
+            border: 1px solid var(--ucla-light-blue);
             border-radius: 0.375rem;
             padding: 0.35rem 0.5rem;
             font-size: 0.75rem;
-            color: #2D3748; /* UCLA Dark Gray */
-            background-color: #ffffff;
+            color: var(--ucla-dark-gray);
+            background-color: var(--ucla-white);
+        }
+        .text-slate-800,
+        .text-slate-900,
+        .text-slate-700 {
+            color: var(--ucla-dark-gray) !important;
+        }
+        .text-slate-600 {
+            color: var(--ucla-medium-gray) !important;
+        }
+        .text-slate-500 {
+            color: var(--ucla-medium-gray) !important;
+        }
+        .text-slate-400 {
+            color: var(--ucla-light-blue) !important;
+        }
+        .text-red-500 {
+            color: var(--ucla-dark-gold) !important;
+        }
+        .bg-slate-50,
+        .bg-slate-100 {
+            background-color: var(--ucla-light-gray) !important;
+        }
+        .border-slate-200,
+        .border-slate-300 {
+            border-color: var(--ucla-medium-gray) !important;
+        }
+        .text-sky-500,
+        .text-sky-700 {
+            color: var(--ucla-blue) !important;
+        }
+        .bg-sky-500 {
+            background-color: var(--ucla-blue) !important;
+        }
+        .text-teal-700 {
+            color: var(--ucla-gold) !important;
+        }
+        .bg-teal-500 {
+            background-color: var(--ucla-gold) !important;
+        }
+        .text-indigo-700 {
+            color: var(--ucla-dark-blue) !important;
+        }
+        .bg-indigo-500 {
+            background-color: var(--ucla-dark-blue) !important;
+        }
+        .text-amber-700 {
+            color: var(--ucla-dark-gold) !important;
+        }
+        .bg-amber-500 {
+            background-color: var(--ucla-dark-gold) !important;
+        }
+        .hover\:bg-slate-100:hover,
+        .hover\:bg-slate-50:hover {
+            background-color: var(--ucla-light-gray) !important;
+        }
+        .hover\:text-slate-900:hover,
+        .hover\:text-slate-800:hover,
+        .hover\:text-slate-700:hover {
+            color: var(--ucla-dark-gray) !important;
+        }
+        .bg-black {
+            background-color: rgba(45, 55, 72, 0.5) !important;
         }
     </style>
 </head>
@@ -620,9 +693,9 @@
             });
             const projectData = {
                 team: [
-                    { name: "Core Execution (Michael & Luis)", workload: 75, color: '#0ea5e9' },
-                    { name: "Strategic Advisory (Iish)", workload: 15, color: '#14b8a6' },
-                    { name: "Content Expertise (Kathy)", workload: 10, color: '#f59e0b' }
+                    { name: "Core Execution (Michael & Luis)", workload: 75, color: '#2774AE' },
+                    { name: "Strategic Advisory (Iish)", workload: 15, color: '#FFD100' },
+                    { name: "Content Expertise (Kathy)", workload: 10, color: '#2D3748' }
                 ],
                 phases: [
                     {


### PR DESCRIPTION
## Summary
- define reusable UCLA brand color variables and apply them across the custom CSS so every component inherits from the official palette
- override Tailwind color utility classes and UI elements to map to UCLA color values, ensuring hover, border, and background states stay on brand
- update chart configuration to rely on UCLA blue, gold, and gray for dataset rendering

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc65436b388331839fac1fc2a5c605