### PR TITLE
Make touchpoint editable, remove dashboards, and add row controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,39 @@
             left: 0;
             z-index: 5;
         }
+        .gantt-task-name .timeline-task-label {
+            display: block;
+            font-weight: 600;
+            color: var(--ucla-dark-gray);
+        }
+        .timeline-task-edit {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+        .timeline-row-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+        .timeline-row-action,
+        .row-control-button {
+            font-size: 0.65rem;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            text-transform: uppercase;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.375rem;
+            border: 1px solid var(--ucla-medium-gray);
+            background-color: var(--ucla-light-gray);
+            color: var(--ucla-dark-gray);
+            transition: background-color 0.2s ease, color 0.2s ease;
+        }
+        .timeline-row-action:hover,
+        .row-control-button:hover {
+            background-color: var(--ucla-blue);
+            color: var(--ucla-white);
+        }
         .gantt-row {
             display: contents;
         }
@@ -220,6 +253,37 @@
             font-weight: 600;
             color: var(--ucla-white);
             font-size: 0.75rem;
+        }
+        .raci-key--dark {
+            background-color: var(--ucla-dark-gray);
+        }
+        .raci-deliverable-edit,
+        .raci-deliverable-display {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+        .raci-deliverable-edit .row-control-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+        .raci-deliverable-display span {
+            display: block;
+        }
+        .raci-deliverable-edit textarea {
+            min-height: 4.5rem;
+        }
+        .timeline-task-edit,
+        .gantt-task-name .timeline-task-label,
+        .raci-deliverable-edit,
+        .raci-deliverable-display {
+            padding-left: calc(0.75rem + var(--indent-level, 0) * 1.25rem);
+        }
+        .timeline-row-action:focus,
+        .row-control-button:focus {
+            outline: none;
+            box-shadow: 0 0 0 2px rgba(39, 116, 174, 0.35);
         }
         .editable-input,
         .editable-select,
@@ -450,30 +514,14 @@
                         <span class="text-slate-600">Focus</span>
                         <input type="text" id="touchpointFocus" class="editable-input border border-slate-300 rounded-md px-2 py-1 text-sm w-56" placeholder="e.g. Curriculum Outline Review" />
                     </label>
+                    <button id="toggleTouchpointLock" type="button" class="table-control-button table-control-button--secondary">
+                        <span aria-hidden="true">🔒</span>
+                        <span>Lock Touchpoint</span>
+                    </button>
                 </div>
             </div>
         </div>
     </header>
-
-    <section class="bg-indigo-50 border-b border-indigo-200">
-        <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-            <div class="flex items-start gap-3">
-                <span class="text-indigo-600 text-xl font-bold" aria-hidden="true">!</span>
-                <div>
-                    <p class="text-indigo-900 font-semibold">Compliance & Transmission Commitments</p>
-                    <ul class="list-disc list-inside text-indigo-800 text-sm space-y-1">
-                        <li>Maintain regular OSH metrics & progress reporting touchpoints to keep compliance checks proactive.</li>
-                        <li>Package clean + tracked versions of every deliverable for OSH to retain and use in perpetuity.</li>
-                    </ul>
-                </div>
-            </div>
-            <div class="bg-white border border-indigo-200 rounded-md p-4 text-sm shadow-sm">
-                <p class="font-semibold text-indigo-900">Final handoff checklist</p>
-                <p class="text-indigo-800">Track progress in <a href="#final-package-checklist" class="text-sky-600 underline">Phase 4 -> Final Handoff Requirements</a>.</p>
-            </div>
-        </div>
-    </section>
-
     <main class="container mx-auto p-4 sm:p-6 lg:p-8">
 
         <!-- Project Overview -->
@@ -627,13 +675,8 @@
                     </div>
                 </div>
             </div>
-            <div class="mt-8 bg-white p-6 rounded-lg shadow-lg">
-                <h3 class="text-lg font-semibold mb-4">4.4. Monthly Reporting Dashboard</h3>
-                <p class="text-slate-600 text-sm mb-4">Capture uptake metrics in one place for the monthly OSH note. Update counts live; values persist in this session for easy copy-out to sheets later.</p>
-                <div id="metrics-dashboard" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
-            </div>
         </section>
-        
+
         <!-- RACI Section -->
         <section id="raci" class="mb-12">
             <h2 class="text-2xl font-bold text-slate-800 mb-4">V. Key Deliverables Schedule & RACI Matrix</h2>
@@ -648,21 +691,12 @@
                 </div>
                 <div class="flex items-center space-x-4 mb-4 text-sm">
                     <span class="font-bold">RACI Key:</span>
-                    <span><span class="raci-key bg-sky-500">R</span> = Responsible</span>
-                    <span><span class="raci-key bg-teal-500">A</span> = Accountable</span>
-                    <span><span class="raci-key bg-indigo-500">C</span> = Consulted</span>
-                    <span><span class="raci-key bg-amber-500">I</span> = Informed</span>
+                    <span><span class="raci-key raci-key--dark">R</span> = Responsible</span>
+                    <span><span class="raci-key raci-key--dark">A</span> = Accountable</span>
+                    <span><span class="raci-key raci-key--dark">C</span> = Consulted</span>
+                    <span><span class="raci-key raci-key--dark">I</span> = Informed</span>
                 </div>
                 <table id="raci-table" class="w-full text-sm raci-table"></table>
-            </div>
-        </section>
-
-        <!-- Dissemination Workbench -->
-        <section id="dissemination" class="mb-12">
-            <h2 class="text-2xl font-bold text-slate-800 mb-4">VI. Dissemination Workbench (D11)</h2>
-            <p class="text-slate-600 mb-6 max-w-3xl">Track comms drafts, approval status, and channel assignments so D11 deliverables move in lockstep with curriculum milestones.</p>
-            <div class="bg-white p-6 rounded-lg shadow-lg">
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4" id="dissemination-grid"></div>
             </div>
         </section>
 
@@ -860,25 +894,10 @@
                     { id: 'D10', deliverable: '[FINAL] Complete K-12 Digital Citizenship Package (Modeled after CDE Ethnic Studies)', dueDate: { type: 'date', value: '2026-06-30' }, R: ['Michael C.', 'Luis C.'], A: ['Michael C.'], C: ['Joe B.', 'CDPH'], I: [], reviewRoute: 'Erin -> Ryan/CDPH OSH', shareStatus: 'Final' },
                     { id: 'D11', deliverable: 'Co-Branded Presentation & Communications Materials', dueDate: { type: 'text', value: 'Ongoing as needed' }, R: ['Geneva S.'], A: ['Michael C.'], C: ['Iish R.'], I: ['Full Team'], reviewRoute: 'Erin -> Ryan/CDPH OSH', shareStatus: 'Shareable draft' },
                 ],
-                metrics: {
-                    trainings: 0,
-                    downloads: 0,
-                    handouts: 0,
-                    comms: 0,
-                    webinar_reg: 0,
-                    webinar_attend: 0
-                },
                 nextTouchpoint: {
                     date: '2026-04-10',
                     focus: 'Curriculum Outline Review with OSH'
-                },
-                dissemination: [
-                    { id: 'press', label: 'Press/announcement copy', channel: 'Press release', approved: false, notes: '' },
-                    { id: 'newsletter', label: 'Newsletter blurb', channel: 'Newsletter', approved: false, notes: '' },
-                    { id: 'webinar', label: 'Webinar descriptions', channel: 'Webinar', approved: false, notes: '' },
-                    { id: 'partner-email', label: 'Partner email copy', channel: 'Partner email', approved: false, notes: '' },
-                    { id: 'listserv', label: 'Listserv posts', channel: 'Listserv', approved: false, notes: '' }
-                ]
+                }
             };
 
             const formatTouchpointDate = (value) => {
@@ -895,6 +914,8 @@
             const touchpointSummary = document.getElementById('touchpointSummary');
             const touchpointDateInput = document.getElementById('touchpointDate');
             const touchpointFocusInput = document.getElementById('touchpointFocus');
+            const toggleTouchpointLockBtn = document.getElementById('toggleTouchpointLock');
+            let isTouchpointLocked = true;
 
             const updateTouchpointSummary = () => {
                 if (!touchpointSummary) {
@@ -906,9 +927,34 @@
                 touchpointSummary.textContent = `${dateText} - ${focusText}`;
             };
 
+            const updateTouchpointLockUI = ({ renderSummary = true } = {}) => {
+                if (toggleTouchpointLockBtn) {
+                    toggleTouchpointLockBtn.innerHTML = isTouchpointLocked
+                        ? '<span aria-hidden="true">🔓</span><span> Unlock Touchpoint</span>'
+                        : '<span aria-hidden="true">🔒</span><span> Lock Touchpoint</span>';
+                    toggleTouchpointLockBtn.setAttribute('aria-pressed', String(isTouchpointLocked));
+                    toggleTouchpointLockBtn.setAttribute('aria-label', isTouchpointLocked ? 'Unlock touchpoint fields for editing' : 'Lock touchpoint fields');
+                    toggleTouchpointLockBtn.classList.add('table-control-button--secondary');
+                    toggleTouchpointLockBtn.classList.toggle('table-control-button--active', isTouchpointLocked);
+                }
+                if (touchpointDateInput) {
+                    touchpointDateInput.disabled = isTouchpointLocked;
+                }
+                if (touchpointFocusInput) {
+                    touchpointFocusInput.disabled = isTouchpointLocked;
+                }
+                if (renderSummary) {
+                    updateTouchpointSummary();
+                }
+            };
+
             if (touchpointDateInput) {
                 touchpointDateInput.value = projectData.nextTouchpoint.date;
                 touchpointDateInput.addEventListener('change', () => {
+                    if (isTouchpointLocked) {
+                        touchpointDateInput.value = projectData.nextTouchpoint.date;
+                        return;
+                    }
                     projectData.nextTouchpoint.date = touchpointDateInput.value;
                     updateTouchpointSummary();
                 });
@@ -917,12 +963,29 @@
             if (touchpointFocusInput) {
                 touchpointFocusInput.value = projectData.nextTouchpoint.focus;
                 touchpointFocusInput.addEventListener('input', () => {
+                    if (isTouchpointLocked) {
+                        touchpointFocusInput.value = projectData.nextTouchpoint.focus;
+                        return;
+                    }
                     projectData.nextTouchpoint.focus = touchpointFocusInput.value;
                     updateTouchpointSummary();
                 });
             }
 
+            if (toggleTouchpointLockBtn) {
+                toggleTouchpointLockBtn.addEventListener('click', () => {
+                    requireAuthentication(() => {
+                        isTouchpointLocked = !isTouchpointLocked;
+                        updateTouchpointLockUI();
+                        if (!isTouchpointLocked && touchpointFocusInput) {
+                            touchpointFocusInput.focus();
+                        }
+                    });
+                });
+            }
+
             updateTouchpointSummary();
+            updateTouchpointLockUI({ renderSummary: false });
 
             const escapeHTML = (value = '') => String(value)
                 .replace(/&/g, '&amp;')
@@ -981,19 +1044,61 @@
                     if (!task.timelineNotes) {
                         task.timelineNotes = {};
                     }
+                    if (typeof task.indentLevel !== 'number') {
+                        task.indentLevel = 0;
+                    }
                 });
+            });
+
+            projectData.raciData.forEach(item => {
+                if (typeof item.indentLevel !== 'number') {
+                    item.indentLevel = 0;
+                }
             });
 
             const getAllTasks = () => projectData.phases.flatMap(phase => phase.tasks.map(task => ({ task, phase })));
 
+            const getMaxTaskId = () => {
+                let maxId = 0;
+                projectData.phases.forEach(phase => {
+                    phase.tasks.forEach(task => {
+                        const numericId = Number(task.id);
+                        if (!Number.isNaN(numericId)) {
+                            maxId = Math.max(maxId, numericId);
+                        }
+                    });
+                });
+                return maxId;
+            };
+
+            let nextTaskId = getMaxTaskId() + 1;
+
+            const getNextTaskId = () => nextTaskId++;
+
             const findTaskById = (id) => {
                 for (const phase of projectData.phases) {
-                    const match = phase.tasks.find(task => task.id === id);
-                    if (match) {
-                        return { task: match, phase };
+                    const taskIndex = phase.tasks.findIndex(task => task.id === id);
+                    if (taskIndex !== -1) {
+                        return { task: phase.tasks[taskIndex], phase, index: taskIndex };
                     }
                 }
                 return null;
+            };
+
+            const createNewTimelineTask = (referenceTask = {}, { indentLevel = 0 } = {}) => {
+                const today = new Date().toISOString().split('T')[0];
+                const baseStart = referenceTask.start || today;
+                const baseEnd = referenceTask.end || baseStart;
+                return {
+                    id: getNextTaskId(),
+                    name: '',
+                    start: baseStart,
+                    end: baseEnd,
+                    owner: [],
+                    details: '',
+                    timelineNotes: {},
+                    indentLevel: Math.max(0, indentLevel)
+                };
             };
 
             const getMonthKey = (date) => `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
@@ -1122,10 +1227,26 @@
                         task.timelineNotes = {};
                     }
                     ganttHTML += `<div class="gantt-row" data-task-id="${task.id}">`;
+                    const indentLevel = Math.max(0, Number(task.indentLevel) || 0);
+                    const indentStyle = `style="--indent-level: ${indentLevel};"`;
                     if (isTimelineLocked) {
-                        ganttHTML += `<div class="gantt-task-name" title="${escapeHTML(task.name)}">${escapeHTML(task.name)}</div>`;
+                        ganttHTML += `<div class="gantt-task-name" data-task-id="${task.id}" title="${escapeHTML(task.name)}"><span class="timeline-task-label" ${indentStyle}>${escapeHTML(task.name)}</span></div>`;
                     } else {
-                        ganttHTML += `<div class="gantt-task-name gantt-task-name--editable"><textarea class="timeline-textarea timeline-textarea--name" data-task-id="${task.id}" data-field="name" placeholder="Task name">${escapeHTML(task.name || '')}</textarea></div>`;
+                        const rowControls = `
+                            <div class="timeline-row-controls">
+                                <button type="button" class="timeline-row-action" data-action="add-above" data-task-id="${task.id}">Row ↑</button>
+                                <button type="button" class="timeline-row-action" data-action="add-below" data-task-id="${task.id}">Row ↓</button>
+                                <button type="button" class="timeline-row-action" data-action="add-sub-above" data-task-id="${task.id}">Sub ↑</button>
+                                <button type="button" class="timeline-row-action" data-action="add-sub-below" data-task-id="${task.id}">Sub ↓</button>
+                            </div>`;
+                        ganttHTML += `
+                            <div class="gantt-task-name gantt-task-name--editable" data-task-id="${task.id}">
+                                <div class="timeline-task-edit" ${indentStyle}>
+                                    ${rowControls}
+                                    <textarea class="timeline-textarea timeline-textarea--name" data-task-id="${task.id}" data-field="name" placeholder="Task name">${escapeHTML(task.name || '')}</textarea>
+                                </div>
+                            </div>
+                        `;
                     }
 
                     months.slice(0, -1).forEach((month, index) => {
@@ -1196,6 +1317,40 @@
             }
 
             updateTimelineLockUI();
+
+            ganttContainer.addEventListener('click', (event) => {
+                if (isTimelineLocked) {
+                    return;
+                }
+                const controlButton = event.target.closest('.timeline-row-action');
+                if (!controlButton) {
+                    return;
+                }
+                const action = controlButton.dataset.action;
+                const taskId = parseInt(controlButton.dataset.taskId, 10);
+                if (!action || Number.isNaN(taskId)) {
+                    return;
+                }
+                const entry = findTaskById(taskId);
+                if (!entry) {
+                    return;
+                }
+                const { task, phase, index } = entry;
+                const baseIndent = Number(task.indentLevel) || 0;
+                const asSubRow = action === 'add-sub-above' || action === 'add-sub-below';
+                const before = action === 'add-above' || action === 'add-sub-above';
+                const newTask = createNewTimelineTask(task, { indentLevel: asSubRow ? baseIndent + 1 : baseIndent });
+                const insertIndex = before ? index : index + 1;
+                phase.tasks.splice(insertIndex, 0, newTask);
+                renderTimeline();
+                requestAnimationFrame(() => {
+                    const textarea = ganttContainer.querySelector(`textarea.timeline-textarea--name[data-task-id="${newTask.id}"]`);
+                    if (textarea) {
+                        textarea.focus();
+                        textarea.select();
+                    }
+                });
+            });
 
             ganttContainer.addEventListener('input', (event) => {
                 if (isTimelineLocked) {
@@ -1308,131 +1463,6 @@
                 });
             });
             
-            // Monthly Reporting Dashboard
-            const metricsContainer = document.getElementById('metrics-dashboard');
-            const metricDefinitions = [
-                { key: 'trainings', label: 'Trainings delivered', hint: 'Workshops, PD sessions, webinars with facilitation.' },
-                { key: 'downloads', label: 'Lesson/resource downloads', hint: 'Curriculum files pulled from the shared drive.' },
-                { key: 'handouts', label: 'Handouts distributed', hint: 'Family one-pagers, classroom posters, quick guides.' },
-                { key: 'comms', label: 'Communications sends', hint: 'Listserv pushes, newsletters, outbound briefings.' },
-                { key: 'webinar_reg', label: 'Webinar registrations', hint: 'Sign-ups captured via RSVP forms.' },
-                { key: 'webinar_attend', label: 'Webinar attendance', hint: 'Live attendees across all sessions.' }
-            ];
-
-            if (metricsContainer) {
-                metricsContainer.innerHTML = metricDefinitions.map(definition => `
-                    <div class="border border-slate-200 rounded-md p-4 shadow-sm space-y-3">
-                        <div>
-                            <p class="font-semibold text-slate-800">${escapeHTML(definition.label)}</p>
-                            <p class="text-xs text-slate-500">${escapeHTML(definition.hint)}</p>
-                        </div>
-                        <div class="flex items-center gap-2">
-                            <button type="button" class="px-3 py-1 border border-slate-300 rounded-md text-slate-700 hover:bg-slate-100" data-action="decrement" data-metric="${definition.key}" aria-label="Decrease ${escapeHTML(definition.label)}">-</button>
-                            <input type="number" min="0" class="metric-input border border-slate-300 rounded-md px-2 py-1 w-20 text-center" data-metric-value="${definition.key}" value="${escapeHTML(String(projectData.metrics[definition.key] ?? 0))}">
-                            <button type="button" class="px-3 py-1 border border-slate-300 rounded-md text-slate-700 hover:bg-slate-100" data-action="increment" data-metric="${definition.key}" aria-label="Increase ${escapeHTML(definition.label)}">+</button>
-                        </div>
-                    </div>
-                `).join('');
-
-                const adjustMetric = (key, delta) => {
-                    const current = Number(projectData.metrics[key]) || 0;
-                    const next = Math.max(0, current + delta);
-                    projectData.metrics[key] = next;
-                    const input = metricsContainer.querySelector(`input[data-metric-value="${key}"]`);
-                    if (input) {
-                        input.value = String(next);
-                    }
-                };
-
-                metricsContainer.addEventListener('click', (event) => {
-                    const button = event.target.closest('[data-action][data-metric]');
-                    if (!button) {
-                        return;
-                    }
-                    const { metric, action } = button.dataset;
-                    const delta = action === 'increment' ? 1 : -1;
-                    adjustMetric(metric, delta);
-                });
-
-                metricsContainer.addEventListener('input', (event) => {
-                    const input = event.target.closest('input[data-metric-value]');
-                    if (!input) {
-                        return;
-                    }
-                    const { metricValue } = input.dataset;
-                    let value = parseInt(input.value, 10);
-                    if (Number.isNaN(value) || value < 0) {
-                        value = 0;
-                    }
-                    projectData.metrics[metricValue] = value;
-                    input.value = String(value);
-                });
-            }
-
-            // Dissemination Workbench
-            const disseminationContainer = document.getElementById('dissemination-grid');
-            const disseminationChannels = ['Press release', 'Newsletter', 'Webinar', 'Partner email', 'Listserv', 'Social media'];
-
-            if (disseminationContainer) {
-                disseminationContainer.innerHTML = projectData.dissemination.map(item => `
-                    <div class="border border-slate-200 rounded-md p-4 shadow-sm space-y-4">
-                        <div class="flex items-center justify-between gap-2">
-                            <h4 class="font-semibold text-slate-800">${escapeHTML(item.label)}</h4>
-                            <label class="flex items-center gap-2 text-sm text-slate-600">
-                                <input type="checkbox" class="h-4 w-4 text-sky-600 border-slate-300 rounded dissemination-approve" data-id="${escapeHTML(item.id)}" ${item.approved ? 'checked' : ''}>
-                                <span data-status-label="${escapeHTML(item.id)}">${item.approved ? 'Approved to send' : 'Needs approval'}</span>
-                            </label>
-                        </div>
-                        <div class="space-y-3 text-sm text-slate-600">
-                            <label class="flex flex-col gap-1">
-                                <span class="text-xs uppercase tracking-wide text-slate-500">Channel</span>
-                                <select class="border border-slate-300 rounded-md px-2 py-1 dissemination-channel" data-id="${escapeHTML(item.id)}">
-                                    ${disseminationChannels.map(channel => `<option value="${escapeHTML(channel)}" ${item.channel === channel ? 'selected' : ''}>${escapeHTML(channel)}</option>`).join('')}
-                                </select>
-                            </label>
-                            <label class="flex flex-col gap-1">
-                                <span class="text-xs uppercase tracking-wide text-slate-500">Notes / next steps</span>
-                                <textarea class="border border-slate-300 rounded-md px-2 py-1 dissemination-notes" data-id="${escapeHTML(item.id)}" style="min-height: 80px;">${escapeHTML(item.notes || '')}</textarea>
-                            </label>
-                        </div>
-                    </div>
-                `).join('');
-
-                disseminationContainer.addEventListener('change', (event) => {
-                    const approveToggle = event.target.closest('.dissemination-approve');
-                    if (approveToggle) {
-                        const item = projectData.dissemination.find(entry => entry.id === approveToggle.dataset.id);
-                        if (item) {
-                            item.approved = approveToggle.checked;
-                            const statusLabel = disseminationContainer.querySelector(`[data-status-label="${escapeSelector(approveToggle.dataset.id)}"]`);
-                            if (statusLabel) {
-                                statusLabel.textContent = item.approved ? 'Approved to send' : 'Needs approval';
-                            }
-                        }
-                        return;
-                    }
-
-                    const channelSelect = event.target.closest('.dissemination-channel');
-                    if (channelSelect) {
-                        const item = projectData.dissemination.find(entry => entry.id === channelSelect.dataset.id);
-                        if (item) {
-                            item.channel = channelSelect.value;
-                        }
-                    }
-                });
-
-                disseminationContainer.addEventListener('input', (event) => {
-                    const notesField = event.target.closest('.dissemination-notes');
-                    if (!notesField) {
-                        return;
-                    }
-                    const item = projectData.dissemination.find(entry => entry.id === notesField.dataset.id);
-                    if (item) {
-                        item.notes = notesField.value;
-                    }
-                });
-            }
-
             // RACI Table
             const raciTable = document.getElementById('raci-table');
             const basePeople = ['Luis C.', 'Michael C.', 'Kathy D.', 'Iish R.', 'Joe B.', 'Geneva S.', 'CDPH', 'Full Team'];
@@ -1553,10 +1583,10 @@
                     <th class="whitespace-nowrap" style="width: 11%;">Due Date<div class="raci-table-resizer" data-column="2"></div></th>
                     <th class="text-wrap" style="width: 16%;">Review Owner / Route<div class="raci-table-resizer" data-column="3"></div></th>
                     <th class="whitespace-nowrap" style="width: 9%;">External Share?<div class="raci-table-resizer" data-column="4"></div></th>
-                    <th style="width: 9%;">R<div class="raci-table-resizer" data-column="5"></div></th>
-                    <th style="width: 9%;">A<div class="raci-table-resizer" data-column="6"></div></th>
-                    <th style="width: 9%;">C<div class="raci-table-resizer" data-column="7"></div></th>
-                    <th style="width: 9%;">I</th>
+                    <th style="width: 9%;"><span class="raci-key raci-key--dark">R</span><div class="raci-table-resizer" data-column="5"></div></th>
+                    <th style="width: 9%;"><span class="raci-key raci-key--dark">A</span><div class="raci-table-resizer" data-column="6"></div></th>
+                    <th style="width: 9%;"><span class="raci-key raci-key--dark">C</span><div class="raci-table-resizer" data-column="7"></div></th>
+                    <th style="width: 9%;"><span class="raci-key raci-key--dark">I</span></th>
                 </tr></thead><tbody>`;
 
                 const rows = projectData.raciData
@@ -1567,11 +1597,16 @@
                     raciHTML += '<tr><td colspan="9" class="py-4 text-center text-slate-500">No deliverables to display.</td></tr>';
                 } else {
                     rows.forEach(({ item, index }) => {
+                        const indentLevel = Math.max(0, Number(item.indentLevel) || 0);
                         if (isRaciLocked) {
                             raciHTML += `
                                 <tr data-index="${index}">
                                     <td class="whitespace-nowrap">${formatDisplayValue(item.id)}</td>
-                                    <td class="text-wrap">${formatDisplayValue(item.deliverable, { placeholder: 'No description', preserveWhitespace: true })}</td>
+                                    <td class="text-wrap">
+                                        <div class="raci-deliverable-display" style="--indent-level: ${indentLevel};">
+                                            ${formatDisplayValue(item.deliverable, { placeholder: 'No description', preserveWhitespace: true })}
+                                        </div>
+                                    </td>
                                     ${createDueDateCellReadOnly(item.dueDate)}
                                     <td class="text-wrap">${formatDisplayValue(item.reviewRoute, { placeholder: 'Route TBD', preserveWhitespace: true })}</td>
                                     <td class="whitespace-nowrap">${formatDisplayValue(item.shareStatus, { placeholder: 'Internal only' })}</td>
@@ -1582,10 +1617,23 @@
                                 </tr>
                             `;
                         } else {
+                            const controlButtons = `
+                                <div class="row-control-group">
+                                    <button type="button" class="row-control-button" data-action="add-above" data-index="${index}">Row ↑</button>
+                                    <button type="button" class="row-control-button" data-action="add-below" data-index="${index}">Row ↓</button>
+                                    <button type="button" class="row-control-button" data-action="add-sub-above" data-index="${index}">Sub ↑</button>
+                                    <button type="button" class="row-control-button" data-action="add-sub-below" data-index="${index}">Sub ↓</button>
+                                </div>
+                            `;
                             raciHTML += `
                                 <tr data-index="${index}">
                                     <td><input type="text" class="editable-input" data-field="id" value="${escapeHTML(item.id || '')}" placeholder="e.g. D12"></td>
-                                    <td><textarea class="editable-textarea text-wrap" rows="2" data-field="deliverable" placeholder="Describe the deliverable">${escapeHTML(item.deliverable || '')}</textarea></td>
+                                    <td>
+                                        <div class="raci-deliverable-edit" style="--indent-level: ${indentLevel};">
+                                            ${controlButtons}
+                                            <textarea class="editable-textarea text-wrap" rows="2" data-field="deliverable" placeholder="Describe the deliverable">${escapeHTML(item.deliverable || '')}</textarea>
+                                        </div>
+                                    </td>
                                     ${createDueDateCellEditable(item.dueDate || { type: 'date', value: '' })}
                                     <td><input type="text" class="editable-input" data-field="reviewRoute" placeholder="e.g. Erin -> Ryan/CDPH OSH" value="${escapeHTML(item.reviewRoute || '')}"></td>
                                     <td>
@@ -1771,10 +1819,75 @@
                 }
             });
 
+            const insertRaciRow = (referenceIndex, { before = false, asSubRow = false } = {}) => {
+                const baseItem = projectData.raciData[referenceIndex];
+                if (!baseItem) {
+                    return;
+                }
+                const indentLevel = Math.max(0, (Number(baseItem.indentLevel) || 0) + (asSubRow ? 1 : 0));
+                const dueDateType = baseItem.dueDate && baseItem.dueDate.type ? baseItem.dueDate.type : 'date';
+                const newItem = {
+                    id: '',
+                    deliverable: '',
+                    dueDate: { type: dueDateType, value: '' },
+                    reviewRoute: '',
+                    shareStatus: 'Internal only',
+                    R: [],
+                    A: [],
+                    C: [],
+                    I: [],
+                    indentLevel
+                };
+                const insertIndex = before ? referenceIndex : referenceIndex + 1;
+                projectData.raciData.splice(insertIndex, 0, newItem);
+                renderRaciTable();
+                requestAnimationFrame(() => {
+                    const newRow = raciTable.querySelector(`tbody tr[data-index="${insertIndex}"]`);
+                    if (!newRow) {
+                        return;
+                    }
+                    const textarea = newRow.querySelector('textarea[data-field="deliverable"]');
+                    if (textarea) {
+                        textarea.focus();
+                        return;
+                    }
+                    const input = newRow.querySelector('input, select, textarea');
+                    if (input) {
+                        input.focus();
+                    }
+                });
+            };
+
             raciTable.addEventListener('click', (event) => {
                 if (isRaciLocked) {
                     return;
                 }
+
+                const controlButton = event.target.closest('.row-control-button');
+                if (controlButton) {
+                    const action = controlButton.dataset.action;
+                    const index = parseInt(controlButton.dataset.index, 10);
+                    if (!action || Number.isNaN(index)) {
+                        return;
+                    }
+                    if (action === 'add-above') {
+                        insertRaciRow(index, { before: true, asSubRow: false });
+                        return;
+                    }
+                    if (action === 'add-below') {
+                        insertRaciRow(index, { before: false, asSubRow: false });
+                        return;
+                    }
+                    if (action === 'add-sub-above') {
+                        insertRaciRow(index, { before: true, asSubRow: true });
+                        return;
+                    }
+                    if (action === 'add-sub-below') {
+                        insertRaciRow(index, { before: false, asSubRow: true });
+                        return;
+                    }
+                }
+
                 const removeButton = event.target.closest('[data-action="remove-assignee"]');
                 if (!removeButton) return;
                 const role = removeButton.dataset.role;
@@ -1838,7 +1951,8 @@
                             R: [],
                             A: [],
                             C: [],
-                            I: []
+                            I: [],
+                            indentLevel: 0
                         });
                         renderRaciTable();
                         const lastRowInput = raciTable.querySelector('tbody tr:last-child input[data-field="id"]');


### PR DESCRIPTION
## Summary
- add a lockable Next OSH Touchpoint control in the header so the date and focus can be edited without diving into the data model
- streamline the layout by removing the compliance alert, monthly reporting dashboard, and dissemination workbench sections
- add styling hooks plus row/sub-row controls to the timeline and RACI table so rows can be inserted above, below, or as indented sub-items during edit mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc768dc5448331b54894cf5ff2cffb