### PR TITLE
Add delete action to timeline rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -1238,6 +1238,7 @@
                                 <button type="button" class="timeline-row-action" data-action="add-below" data-task-id="${task.id}">Row ↓</button>
                                 <button type="button" class="timeline-row-action" data-action="add-sub-above" data-task-id="${task.id}">Sub ↑</button>
                                 <button type="button" class="timeline-row-action" data-action="add-sub-below" data-task-id="${task.id}">Sub ↓</button>
+                                <button type="button" class="timeline-row-action" data-action="delete" data-task-id="${task.id}">Delete</button>
                             </div>`;
                         ganttHTML += `
                             <div class="gantt-task-name gantt-task-name--editable" data-task-id="${task.id}">
@@ -1336,6 +1337,34 @@
                     return;
                 }
                 const { task, phase, index } = entry;
+
+                if (action === 'delete') {
+                    const tasks = phase.tasks;
+                    const baseIndent = Number(task.indentLevel) || 0;
+                    let removeCount = 1;
+                    for (let i = index + 1; i < tasks.length; i += 1) {
+                        const nextIndent = Number(tasks[i].indentLevel) || 0;
+                        if (nextIndent > baseIndent) {
+                            removeCount += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    tasks.splice(index, removeCount);
+                    renderTimeline();
+                    requestAnimationFrame(() => {
+                        const neighbor = phase.tasks[index] || phase.tasks[index - 1];
+                        if (neighbor) {
+                            const textarea = ganttContainer.querySelector(`textarea.timeline-textarea--name[data-task-id="${neighbor.id}"]`);
+                            if (textarea) {
+                                textarea.focus();
+                                textarea.select();
+                            }
+                        }
+                    });
+                    return;
+                }
+
                 const baseIndent = Number(task.indentLevel) || 0;
                 const asSubRow = action === 'add-sub-above' || action === 'add-sub-below';
                 const before = action === 'add-above' || action === 'add-sub-above';


### PR DESCRIPTION
## Summary
- add a delete control to each editable timeline row
- handle delete actions by removing the task and its nested subtasks before re-rendering
- keep focus on a nearby task after deletion while respecting the timeline lock state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc817982688331b0aa92d4d7c71c70