### PR TITLE
Add delete control for RACI rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -1623,6 +1623,7 @@
                                     <button type="button" class="row-control-button" data-action="add-below" data-index="${index}">Row ↓</button>
                                     <button type="button" class="row-control-button" data-action="add-sub-above" data-index="${index}">Sub ↑</button>
                                     <button type="button" class="row-control-button" data-action="add-sub-below" data-index="${index}">Sub ↓</button>
+                                    <button type="button" class="row-control-button row-control-delete" data-action="delete-row" data-index="${index}">Delete</button>
                                 </div>
                             `;
                             raciHTML += `
@@ -1819,6 +1820,27 @@
                 }
             });
 
+            const focusRaciRow = (rowIndex) => {
+                if (rowIndex < 0) {
+                    return;
+                }
+                requestAnimationFrame(() => {
+                    const row = raciTable.querySelector(`tbody tr[data-index="${rowIndex}"]`);
+                    if (!row) {
+                        return;
+                    }
+                    const textarea = row.querySelector('textarea[data-field="deliverable"]');
+                    if (textarea) {
+                        textarea.focus();
+                        return;
+                    }
+                    const input = row.querySelector('input, select, textarea');
+                    if (input) {
+                        input.focus();
+                    }
+                });
+            };
+
             const insertRaciRow = (referenceIndex, { before = false, asSubRow = false } = {}) => {
                 const baseItem = projectData.raciData[referenceIndex];
                 if (!baseItem) {
@@ -1841,21 +1863,7 @@
                 const insertIndex = before ? referenceIndex : referenceIndex + 1;
                 projectData.raciData.splice(insertIndex, 0, newItem);
                 renderRaciTable();
-                requestAnimationFrame(() => {
-                    const newRow = raciTable.querySelector(`tbody tr[data-index="${insertIndex}"]`);
-                    if (!newRow) {
-                        return;
-                    }
-                    const textarea = newRow.querySelector('textarea[data-field="deliverable"]');
-                    if (textarea) {
-                        textarea.focus();
-                        return;
-                    }
-                    const input = newRow.querySelector('input, select, textarea');
-                    if (input) {
-                        input.focus();
-                    }
-                });
+                focusRaciRow(insertIndex);
             };
 
             raciTable.addEventListener('click', (event) => {
@@ -1884,6 +1892,18 @@
                     }
                     if (action === 'add-sub-below') {
                         insertRaciRow(index, { before: false, asSubRow: true });
+                        return;
+                    }
+                    if (action === 'delete-row') {
+                        if (!projectData.raciData[index]) {
+                            return;
+                        }
+                        projectData.raciData.splice(index, 1);
+                        renderRaciTable();
+                        const nextFocusIndex = Math.min(index, projectData.raciData.length - 1);
+                        if (nextFocusIndex >= 0) {
+                            focusRaciRow(nextFocusIndex);
+                        }
                         return;
                     }
                 }


### PR DESCRIPTION
## Summary
- add a delete control to each editable RACI row
- centralize RACI row focusing logic for reuse
- handle delete actions by removing the row and focusing the next sensible row

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc81889a7483319e0406cd7ce03e95